### PR TITLE
feat: implement PCA transform, fit using `sklearn`

### DIFF
--- a/ibisml/steps/__init__.py
+++ b/ibisml/steps/__init__.py
@@ -3,6 +3,7 @@ from ibisml.steps.decompose import PCA
 from ibisml.steps.encode import CategoricalEncode, OneHotEncode
 from ibisml.steps.impute import FillNA, ImputeMean, ImputeMedian, ImputeMode
 from ibisml.steps.standardize import ScaleMinMax, ScaleStandard
+from ibisml.steps.temporal import ExpandDate, ExpandDateTime, ExpandTime
 
 __all__ = (
     "Cast",

--- a/ibisml/steps/__init__.py
+++ b/ibisml/steps/__init__.py
@@ -3,6 +3,7 @@ from ibisml.steps.impute import FillNA, ImputeMean, ImputeMedian, ImputeMode
 from ibisml.steps.standardize import ScaleMinMax, ScaleStandard
 from ibisml.steps.encode import OneHotEncode, CategoricalEncode
 from ibisml.steps.temporal import ExpandDateTime, ExpandDate, ExpandTime
+from ibisml.steps.decompose import PCA
 
 
 __all__ = (
@@ -21,4 +22,5 @@ __all__ = (
     "ExpandDateTime",
     "ExpandDate",
     "ExpandTime",
+    "PCA",
 )

--- a/ibisml/steps/decompose.py
+++ b/ibisml/steps/decompose.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import warnings
+from typing import TYPE_CHECKING, Any, Iterable
 
-import ibis.expr.types as ir
 import numpy as np
 import sklearn.decomposition
 
 from ibisml.core import Metadata, Step
 from ibisml.select import SelectionType, selector
+
+if TYPE_CHECKING:
+    import ibis.expr.types as ir
 
 
 class PCA(Step):
@@ -36,6 +39,7 @@ class PCA(Step):
         warnings.warn(
             f"{type(self)} cannot be fit natively; falling back to scikit-learn.",
             PerformanceWarning,
+            stacklevel=2,
         )
         columns = self.inputs.select_columns(table, metadata)
         X = table[columns].to_pandas()  # TODO(deepyaman): Handle empty selection given.

--- a/ibisml/steps/decompose.py
+++ b/ibisml/steps/decompose.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import warnings
+
+import ibis.expr.types as ir
+import numpy as np
+import sklearn.decomposition
+
+from ibisml.core import Metadata, Step
+from ibisml.select import SelectionType, selector
+
+
+class PCA(Step):
+    """A step for principal component analysis (PCA).
+
+    Parameters
+    ----------
+    inputs
+        A selection of columns to transform.
+    n_components
+        Number of components to keep.
+    """
+
+    def __init__(
+        self, inputs: SelectionType, n_components: int | float | str | None = None
+    ):
+        self.inputs = selector(inputs)
+        self.n_components = n_components
+
+    def _repr(self) -> Iterable[tuple[str, Any]]:
+        yield ("", self.inputs)
+        yield ("", self.n_components)
+
+    def fit_table(self, table: ir.Table, metadata: Metadata) -> None:
+        PerformanceWarning = RuntimeWarning  # TODO(deepyaman): Define a custom warning.
+        warnings.warn(
+            f"{type(self)} cannot be fit natively; falling back to scikit-learn.",
+            PerformanceWarning,
+        )
+        columns = self.inputs.select_columns(table, metadata)
+        X = table[columns].to_pandas()  # TODO(deepyaman): Handle empty selection given.
+        pca = sklearn.decomposition.PCA(n_components=self.n_components).fit(X)
+
+        # TODO(deepyaman): Consider defining list of attributes to copy.
+        self.components_ = pca.components_
+        self.explained_variance_ = pca.explained_variance_
+        self.explained_variance_ratio_ = pca.explained_variance_ratio_
+        self.singular_values_ = pca.singular_values_
+        self.mean_ = pca.mean_
+        self.n_components_ = pca.n_components_
+        self.n_samples_ = pca.n_samples_
+        self.noise_variance_ = pca.noise_variance_
+        self.n_features_in_ = pca.n_features_in_
+        self.feature_names_in_ = np.asarray(X.columns, dtype=object)
+
+    def transform_table(self, table: ir.Table) -> ir.Table:
+        X = table[self.feature_names_in_]
+
+        # X = X - self.mean_
+        X = X[
+            (
+                (X[c] - self.mean_[i]).name(c)
+                for i, c in enumerate(self.feature_names_in_)
+            )
+        ]
+
+        # X_transformed = X @ self.components_.T
+        def _dot_product(X, v):
+            return sum(X[i] * vi for i, vi in enumerate(v))
+
+        X_transformed = X[
+            (
+                _dot_product(X, self.components_[k]).name(f"PC{k + 1}")
+                for k in range(self.n_components_)
+            )
+        ]
+
+        return X_transformed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ select = [
 ignore = [
   "COM812", # missing-trailing-comma
   "ISC001", # single-line-implicit-string-concatenation
+  "RET504", # unnecessary-assign, stylistic choice
   "RET505", # superfluous-else-return, stylistic choice
   "TD003",  # missing-todo-link
 ]


### PR DESCRIPTION
# Example

PCA two ways:

```pycon
>>> import ibis
>>> import ibisml as ml
>>> from sklearn.decomposition import PCA
>>> from sklearn.pipeline import Pipeline
>>> 
>>> penguins = ibis.examples.penguins.fetch()
>>> 
>>> # Fit PCA as part of Ibis-ML pipeline, and transform using Ibis on DuckDB (new functionality)
>>> recipe = ml.Recipe(ml.ImputeMean(ml.numeric()), ml.PCA(['bill_length_mm', 'bill_depth_mm', 'flipper_length_mm', 'body_mass_g'], n_components=3))
>>> pipeline = Pipeline([("recipe", recipe)])
>>> pipeline.fit(penguins)
/Users/deepyaman/github/ibis-project/ibisml/ibisml/steps/decompose.py:36: RuntimeWarning: <class 'ibisml.steps.decompose.PCA'> cannot be fit natively; falling back to scikit-learn.
  warnings.warn(
Pipeline(steps=[('recipe', <ibisml.core.Recipe object at 0x1636b25f0>)])
>>> pipeline.transform(penguins)
array([[-4.52023209e+02,  1.33366364e+01,  1.14798019e+00],
       [-4.01949980e+02,  9.15269401e+00, -9.03734153e-02],
       [-9.51740904e+02, -8.26147557e+00, -2.35184450e+00],
       ...,
       [-4.26799926e+02, -9.13676765e-01,  7.48871320e+00],
       [-1.01577121e+02, -1.21656299e+01,  4.00939446e+00],
       [-4.26721701e+02, -5.78747970e+00,  6.65750996e+00]])
>>> 
>>> # Fit and transform PCA as part of scikit-learn pipeline (existing functionality)
>>> recipe = ml.Recipe(ml.ImputeMean(ml.numeric()), ml.Drop(~ml.numeric()), ml.Drop('year'))
>>> pipeline = Pipeline([("recipe", recipe), ("pca", PCA(n_components=3))])
>>> pipeline.fit(penguins)
Pipeline(steps=[('recipe', <ibisml.core.Recipe object at 0x165bb1db0>),
                ('pca', PCA(n_components=3))])
>>> pipeline.transform(penguins)
array([[-4.52023209e+02,  1.33366364e+01,  1.14798019e+00],
       [-4.01949980e+02,  9.15269401e+00, -9.03734153e-02],
       [-9.51740904e+02, -8.26147557e+00, -2.35184450e+00],
       ...,
       [-4.26799926e+02, -9.13676765e-01,  7.48871320e+00],
       [-1.01577121e+02, -1.21656299e+01,  4.00939446e+00],
       [-4.26721701e+02, -5.78747970e+00,  6.65750996e+00]])
```