### PR TITLE
tests: test DiscretizeKBins and CreatePolynomialFeatures on different backends

### DIFF
--- a/ibis_ml/steps/_discretize.py
+++ b/ibis_ml/steps/_discretize.py
@@ -99,7 +99,8 @@ class DiscretizeKBins(Step):
             aggs.append(col.max().name(f"{col_name}_max"))
             aggs.append(col.min().name(f"{col_name}_min"))
 
-        results = table.aggregate(aggs).execute().to_dict("records")[0]
+        self.expr = table.aggregate(aggs)
+        results = self.expr.execute().to_dict("records")[0]
 
         return {
             col_name: np.linspace(
@@ -121,7 +122,8 @@ class DiscretizeKBins(Step):
                 )
             aggs.extend([col.quantile(q).name(f"{col_name}_{q}") for q in percentiles])
 
-        results = table.aggregate(aggs).execute().to_dict("records")[0]
+        self.expr = table.aggregate(aggs)
+        results = self.expr.execute().to_dict("records")[0]
 
         return {
             col_name: [results[f"{col_name}_{q}"] for q in percentiles]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+from ibis.backends import _get_backend_names
+from ibis.backends.conftest import pytest_runtest_call  # noqa: F401
+
+ALL_BACKENDS = set(_get_backend_names())
+
+
+@pytest.fixture(params=ALL_BACKENDS, scope="session")
+def backend(request):
+    return request.param

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,0 +1,72 @@
+import ibis
+import ibis.common.exceptions as com
+import pytest
+
+import ibis_ml as ml
+
+
+@pytest.mark.notimpl(
+    [
+        "bigquery",
+        "mysql",
+        "sqlite",
+        "mssql",
+        "trino",
+        "flink",
+        "druid",
+        "datafusion",
+        "impala",
+        "exasol",
+    ],
+    raises=com.OperationNotDefinedError,
+    reason="Quantile is not supported",
+)
+@pytest.mark.notimpl(
+    ["pandas", "polars", "dask"],
+    raises=NotImplementedError,
+    reason="Backend doesn't support SQL",
+)
+def test_discretize_quantile(backend):
+    train_table = ibis.memtable({"col": range(1, 11)})
+    step = ml.DiscretizeKBins("col", n_bins=9, strategy="quantile")
+    step.fit_table(train_table, ml.core.Metadata())
+    t = step.transform_table(train_table)
+
+    fit_table_sql = ibis.to_sql(step.expr.op().to_expr(), dialect=backend)
+    assert fit_table_sql is not None
+
+    transform_table_sql = ibis.to_sql(t)
+    assert transform_table_sql is not None
+
+
+@pytest.mark.notimpl(
+    ["pandas", "polars", "dask"],
+    raises=NotImplementedError,
+    reason="Backend doesn't support SQL",
+)
+def test_discretize_uniform(backend):
+    train_table = ibis.memtable({"col": range(1, 11)})
+    step = ml.DiscretizeKBins("col", n_bins=9, strategy="uniform")
+    step.fit_table(train_table, ml.core.Metadata())
+    t = step.transform_table(train_table)
+
+    fit_table_sql = ibis.to_sql(step.expr.op().to_expr(), dialect=backend)
+    assert fit_table_sql is not None
+
+    transform_table_sql = ibis.to_sql(t)
+    assert transform_table_sql is not None
+
+
+@pytest.mark.notimpl(
+    ["pandas", "polars", "dask"],
+    raises=NotImplementedError,
+    reason="Backend doesn't support SQL",
+)
+def test_create_polynomial_features(backend):
+    N = 10
+    train_table = ibis.memtable({"x": list(range(N)), "y": [10] * N})
+    step = ml.CreatePolynomialFeatures(ml.numeric(), degree=2)
+    step.fit_table(train_table, ml.core.Metadata())
+    t = step.transform_table(train_table)
+    transform_table_sql = ibis.to_sql(t)
+    assert transform_table_sql is not None


### PR DESCRIPTION
Hi,

I am not sure if this is the right way to test `Step` on different backends. I just use this as the start point for collecting better solutions and feedbacks. I tried this solution on two Step: `DiscretizeKBins ` and `CreatePolynomialFeatures `

The main idea is to see if the operators used in `fit_table()` and `transform_table` could be compiled to sql of different backend. 

- For `fit_table()`, I save the intermediate fitting expression as a instance variable `self.expr` and later to check if it is could be transpiled into different dialect.
- For `transform_table`, just to compile the output table.