### PR TITLE
ci: add a unique identifier to publish to TestPyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Add unique post-release segment to publish to TestPyPI
+        if: "!startsWith(github.ref, 'refs/tags/')" # only modify version when publishing to TestPyPI
+        run: sed -i "s/^version = \"\([0-9]\+\.[0-9]\+\.[0-9]\+\)\"$/\1.post$(date +%s)/" ibis_ml/__init__.py
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
The TestPyPI publishing step fails right now, because the version already exists.

Chose to create a post-release (instead of a development release), since it will be installable without any additional flags (`--pre`). While it's not recommended to modify code in post-releases, this is only for TestPyPI publishing (i.e. nobody should be consuming it, anyway).