### PR TITLE
fix(docs): fix dask in support matrix

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11.8" # TODO(deepyaman): Update Python version when Ibis supports `dask>=2024.4.1`, which added https://github.com/dask/dask/pull/11035.
           cache: "pip"
 
       - name: Set up Quarto


### PR DESCRIPTION
Dask had an issue of this ```TypeError: descriptor '__call__' for 'type' objects doesn't apply to a 'property' object``` for lower version.  The support of dask is not calculated because the dask error. 

![image](https://github.com/ibis-project/ibis-ml/assets/126802425/680e6182-08c6-4e47-807c-24e3c6ceee33)


I update dask to its latest version, it solves the problem. 

Check with https://github.com/dask/dask/pull/11035 for details.


Rendered webpage:  https://jitingxu1.github.io/ibis-ml/support_matrix.html


![image](https://github.com/ibis-project/ibis-ml/assets/126802425/9f85d721-46ed-4200-b352-e542ef3c7179)



