### PR TITLE
docs(website): shorten "scikit-learn" to "sklearn"

### DIFF
--- a/docs/tutorial/_tool-chooser.md
+++ b/docs/tutorial/_tool-chooser.md
@@ -3,7 +3,7 @@
   <h3 class="no-anchor">Choose your tool</h3>
   <li class="nav-item" role="presentation">
     <a class="nav-link" href="scikit-learn.html">
-      <img src="images/scikit-learn-logo.svg">scikit-learn
+      <img src="images/scikit-learn-logo.svg">sklearn
     </a>
   </li>
   <li class="nav-item" role="presentation">


### PR DESCRIPTION
"scikit-learn" rendered across two lines, elongating the box and causing inconsistency:

<img width="1470" alt="image" src="https://github.com/ibis-project/ibis-ml/assets/14007150/4e61f6ac-6d68-4b63-9668-fca83cb53ba6">
