### PR TITLE
feat(utils): provide a `train_test_split` function

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -84,6 +84,10 @@ website:
           contents:
             - reference/support-matrix/index.qmd
 
+        - section: Utilities
+          contents:
+            - reference/train-test-split.qmd
+
 format:
   html:
     theme:
@@ -224,3 +228,15 @@ quartodoc:
             - Drop
             - MutateAt
             - Mutate
+
+    - title: Utilities
+      desc: Utility functions
+      package: ibis_ml
+      contents:
+        - kind: page
+          path: train-test-split
+          summary:
+            name: Train test split
+            desc: Randomly split Ibis table
+          contents:
+            - train_test_split

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -86,7 +86,7 @@ website:
 
         - section: Utilities
           contents:
-            - reference/train-test-split.qmd
+            - reference/utils-train-test-split.qmd
 
 format:
   html:
@@ -234,9 +234,9 @@ quartodoc:
       package: ibis_ml
       contents:
         - kind: page
-          path: train-test-split
+          path: utils-train-test-split
           summary:
-            name: Train test split
+            name: Train-test split
             desc: Randomly split Ibis table
           contents:
             - train_test_split

--- a/ibis_ml/__init__.py
+++ b/ibis_ml/__init__.py
@@ -28,6 +28,7 @@ from ibis_ml.select import (
 )
 from ibis_ml.steps import *
 from ibis_ml.utils._pprint import _pprint_recipe, _pprint_step, _safe_repr
+from ibis_ml.utils._train_test_split import train_test_split
 
 # Add support for `Recipe`s and `Step`s to the built-in `PrettyPrinter`.
 pprint.PrettyPrinter._dispatch[Recipe.__repr__] = _pprint_recipe  # noqa: SLF001

--- a/ibis_ml/utils/_train_test_split.py
+++ b/ibis_ml/utils/_train_test_split.py
@@ -9,24 +9,81 @@ def train_test_split(
     table: ir.Table,
     unique_key: str | list[str],
     test_size: float = 0.25,
-    random_state=42,
+    num_buckets: int = 100,
+    random_seed: int | None = None,
 ) -> tuple[ir.Table, ir.Table]:
+    """Randomly split Ibis table data into training and testing tables.
 
+    This function splits an Ibis table into training and testing tables
+    based on a unique key or combination of keys. It uses a hashing function to
+    convert the unique key into an integer, then applies a modulo operation to split
+    the data into buckets. The training table consists of data points from a subset of
+    these buckets, while the remaining data points form the test table.
+
+    Parameters
+    ----------
+    table
+        The input Ibis table to be split.
+    unique_key
+        The column name(s) that uniquely identify each row in the table. This unique_key
+        is used to create a deterministic split of the dataset through a hashing
+        process.
+    test_size
+        The ratio of the dataset to include in the test split, which should be between
+        0 and 1. This ratio is approximate because the hashing algorithm may not provide
+        a uniform bucket distribution for small datasets. Larger datasets will result in
+        more uniform bucket assignments, making the split ratio closer to the desired
+        value.
+    num_buckets
+        The number of buckets into which the data is divided during the splitting
+        process. It controls how finely the data is divided into buckets during
+        the split process. Adjusting num_buckets can affect the granularity and
+        efficiency of the splitting operation, balancing between accuracy and
+        computational efficiency.
+    random_seed
+        Seed for the random number generator. If provided, ensures reproducibility
+        of the split.
+
+    Returns
+    -------
+    tuple(ir.Table, ir.Table)
+        A tuple containing two Ibis tables: (train_table, test_table).
+
+    Raises
+    ----------
+    ValueError
+        If test_size is not a float between 0 and 1.
+
+    Examples
+    --------
+    >>> import ibis_ml as ml
+
+    Split an Ibis table into training and testing tables.
+
+    >>> table = ibis.memtable({"key1": range(100)})
+    >>> train_table, test_table = ml.train_test_split(
+            table,
+            unique_key="key1",
+            test_size=0.2,
+            random_seed=0,
+        )
+    """
     if not (0 < test_size < 1):
         raise ValueError("test size should be a float between 0 and 1.")
 
     # Set the random seed for reproducibility
-    random.seed(random_state)
+    if random_seed:
+        random.seed(random_seed)
     # Generate a random 256-bit key
     random_key = str(random.getrandbits(256))
-    # set the number of buckets
-    num_buckets = 100000
 
     if isinstance(unique_key, str):
         unique_key = [unique_key]
 
     table = table.mutate(
-        combined_key=ibis.literal("").join(table[col].cast("str") for col in unique_key)
+        combined_key=ibis.literal(",").join(
+            table[col].cast("str") for col in unique_key
+        )
     ).mutate(
         train=(_.combined_key + random_key).hash().abs() % num_buckets
         < int((1 - test_size) * num_buckets)

--- a/ibis_ml/utils/_train_test_split.py
+++ b/ibis_ml/utils/_train_test_split.py
@@ -46,11 +46,11 @@ def train_test_split(
 
     Returns
     -------
-    tuple(ir.Table, ir.Table)
+    tuple[ir.Table, ir.Table]
         A tuple containing two Ibis tables: (train_table, test_table).
 
     Raises
-    ----------
+    ------
     ValueError
         If test_size is not a float between 0 and 1.
 
@@ -74,6 +74,7 @@ def train_test_split(
     # Set the random seed for reproducibility
     if random_seed:
         random.seed(random_seed)
+
     # Generate a random 256-bit key
     random_key = str(random.getrandbits(256))
 

--- a/ibis_ml/utils/_train_test_split.py
+++ b/ibis_ml/utils/_train_test_split.py
@@ -1,0 +1,37 @@
+import random
+
+import ibis
+import ibis.expr.types as ir
+from ibis import _
+
+
+def train_test_split(
+    table: ir.Table,
+    unique_key: str | list[str],
+    test_size: float = 0.25,
+    random_state=42,
+) -> tuple[ir.Table, ir.Table]:
+
+    if not (0 < test_size < 1):
+        raise ValueError("test size should be a float between 0 and 1.")
+
+    # Set the random seed for reproducibility
+    random.seed(random_state)
+    # Generate a random 256-bit key
+    random_key = str(random.getrandbits(256))
+    # set the number of buckets
+    num_buckets = 100000
+
+    if isinstance(unique_key, str):
+        unique_key = [unique_key]
+
+    table = table.mutate(
+        combined_key=ibis.literal("").join(table[col].cast("str") for col in unique_key)
+    ).mutate(
+        train=(_.combined_key + random_key).hash().abs() % num_buckets
+        < int((1 - test_size) * num_buckets)
+    )
+
+    return table[table.train].drop(["combined_key"]), table[~table.train].drop(
+        ["combined_key"]
+    )

--- a/tests/test_train_test_split.py
+++ b/tests/test_train_test_split.py
@@ -1,0 +1,32 @@
+import ibis
+import pandas.testing as tm
+
+import ibis_ml as ml
+
+
+def test_train_test_split():
+    N = 100
+    test_size = 0.25
+    table = ibis.memtable({"key1": range(N)})
+
+    train_table, test_table = ml.train_test_split(
+        table, unique_key="key1", test_size=test_size, random_state=42
+    )
+
+    # Check counts and overlaps in train and test dataset
+    assert train_table.count().execute() + test_table.count().execute() == N
+    assert train_table.intersect(test_table).count().execute() == 0
+
+    # Check reproducibility
+    reproduced_train_table, reproduced_test_table = ml.train_test_split(
+        table, unique_key="key1", test_size=test_size, random_state=42
+    )
+    tm.assert_frame_equal(train_table.execute(), reproduced_train_table.execute())
+    tm.assert_frame_equal(test_table.execute(), reproduced_test_table.execute())
+
+    # make sure it could generate different data with different random state
+    different_train_table, different_test_table = ml.train_test_split(
+        table, unique_key="key1", test_size=test_size, random_state=0
+    )
+    assert not train_table.execute().equals(different_train_table.execute())
+    assert not test_table.execute().equals(different_test_table.execute())

--- a/tests/test_train_test_split.py
+++ b/tests/test_train_test_split.py
@@ -10,7 +10,7 @@ def test_train_test_split():
     table = ibis.memtable({"key1": range(N)})
 
     train_table, test_table = ml.train_test_split(
-        table, unique_key="key1", test_size=test_size, random_state=42
+        table, unique_key="key1", test_size=test_size, random_seed=42
     )
 
     # Check counts and overlaps in train and test dataset
@@ -19,14 +19,14 @@ def test_train_test_split():
 
     # Check reproducibility
     reproduced_train_table, reproduced_test_table = ml.train_test_split(
-        table, unique_key="key1", test_size=test_size, random_state=42
+        table, unique_key="key1", test_size=test_size, random_seed=42
     )
     tm.assert_frame_equal(train_table.execute(), reproduced_train_table.execute())
     tm.assert_frame_equal(test_table.execute(), reproduced_test_table.execute())
 
-    # make sure it could generate different data with different random state
+    # make sure it could generate different data with different random_seed
     different_train_table, different_test_table = ml.train_test_split(
-        table, unique_key="key1", test_size=test_size, random_state=0
+        table, unique_key="key1", test_size=test_size, random_seed=0
     )
     assert not train_table.execute().equals(different_train_table.execute())
     assert not test_table.execute().equals(different_test_table.execute())


### PR DESCRIPTION
add train test split based on the functions in the [tutorial](https://ibis-project.github.io/ibis-ml/tutorial/pytorch.html).

Not sure if this is the right module for this utility function, I am open to all kids of recommendation.

Another Reference: https://engineeringfordatascience.com/posts/ml_repeatable_splitting_using_hashing/

<img width="801" alt="image" src="https://github.com/ibis-project/ibis-ml/assets/126802425/ad513d14-a8ce-4f62-a73a-f7fbbf2e99a5">
