### PR TITLE
fix(website): restore padding to Bootstrap default

### DIFF
--- a/docs/theme-dark.scss
+++ b/docs/theme-dark.scss
@@ -1,6 +1,8 @@
 /*-- scss:defaults --*/
 $code-color: #c2d94c;
 
+$nav-link-padding-x: 1rem !default;
+
 /*-- scss:rules --*/
 .bi-zulip::before {
   content: url(./zulip-logo-dark.svg);

--- a/docs/theme-light.scss
+++ b/docs/theme-light.scss
@@ -1,3 +1,6 @@
+/*-- scss:defaults --*/
+$nav-link-padding-x: 1rem !default;
+
 /*-- scss:rules --*/
 .quarto-title-banner .quarto-title .title {
   color: #ccd1d5;


### PR DESCRIPTION
TL;DR the tool chooser CSS is predicated on `1rem` padding, not `2rem`

We need to overwrite this: https://github.com/quarto-dev/quarto-cli/blob/v1.5.52/src/resources/formats/html/bootstrap/themes/flatly.scss#L68

See the problem:

<img width="1470" alt="image" src="https://github.com/ibis-project/ibis-ml/assets/14007150/33eb18b5-a9e7-4097-9505-53613d19580d">

It's correct on the Quarto website:

<img width="1470" alt="image" src="https://github.com/ibis-project/ibis-ml/assets/14007150/727de398-fbaf-4a07-b7fe-4be697e1a2dc">

Now it looks good:

<img width="1470" alt="image" src="https://github.com/ibis-project/ibis-ml/assets/14007150/70868ae1-bb24-41be-998a-d522d3282110">

Also in dark mode:

<img width="1470" alt="image" src="https://github.com/ibis-project/ibis-ml/assets/14007150/a96bc038-82c7-4c0a-b8d8-5d6603035626">
