### PR TITLE
docs(website): generalize name to "Data splitting"

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -86,7 +86,7 @@ website:
 
         - section: Utilities
           contents:
-            - reference/utils-train-test-split.qmd
+            - reference/utils-data-splitting.qmd
 
 format:
   html:
@@ -204,7 +204,7 @@ quartodoc:
           path: steps-outlier-handling
           summary:
             name: Outlier handling
-            desc: Handle outliers
+            desc: Outlier detection and handling
           contents:
             - HandleUnivariateOutliers
 
@@ -234,9 +234,9 @@ quartodoc:
       package: ibis_ml
       contents:
         - kind: page
-          path: utils-train-test-split
+          path: utils-data-splitting
           summary:
-            name: Train-test split
-            desc: Randomly split Ibis table
+            name: Data splitting
+            desc: Segregating data into training, testing, and validation sets
           contents:
             - train_test_split

--- a/ibis_ml/__init__.py
+++ b/ibis_ml/__init__.py
@@ -28,7 +28,7 @@ from ibis_ml.select import (
 )
 from ibis_ml.steps import *
 from ibis_ml.utils._pprint import _pprint_recipe, _pprint_step, _safe_repr
-from ibis_ml.utils._train_test_split import train_test_split
+from ibis_ml.utils._split import train_test_split
 
 # Add support for `Recipe`s and `Step`s to the built-in `PrettyPrinter`.
 pprint.PrettyPrinter._dispatch[Recipe.__repr__] = _pprint_recipe  # noqa: SLF001

--- a/ibis_ml/utils/_split.py
+++ b/ibis_ml/utils/_split.py
@@ -62,11 +62,11 @@ def train_test_split(
 
     >>> table = ibis.memtable({"key1": range(100)})
     >>> train_table, test_table = ml.train_test_split(
-            table,
-            unique_key="key1",
-            test_size=0.2,
-            random_seed=0,
-        )
+    ...     table,
+    ...     unique_key="key1",
+    ...     test_size=0.2,
+    ...     random_seed=0,
+    ... )
     """
     if not (0 < test_size < 1):
         raise ValueError("test size should be a float between 0 and 1.")


### PR DESCRIPTION
When I went to visit the website, I saw a train-test split section with a train-test split function; it makes sense for the section to be a bit more generalized, both to perhaps include things like CV in the future, should we add it, and to just be less redundant.