### PR TITLE
Update scikit-learn.qmd

### DIFF
--- a/docs/tutorial/scikit-learn.qmd
+++ b/docs/tutorial/scikit-learn.qmd
@@ -23,7 +23,7 @@ and so on. If you are familiar with [scikit-learn's dataset transformations](htt
 To use code in this article, you will need to install the following packages: Ibis, IbisML, and scikit-learn.
 
 ```bash
-pip install 'ibis-framework[duckdb,examples]' ibis-ml scikit-learn
+pip install 'ibis-framework[duckdb,examples]' ibis-ml scikit-learn gcsfs
 ```
 
 ## The New York City flight data


### PR DESCRIPTION
I got an error message when trying to run this example locally because the Google Cloud Storage Python package seemed missing. Figured I might make a PR to add the installation to the quickstart for sklearn.