### PR TITLE
feat(core): implement `get_params()` API for steps

### DIFF
--- a/ibis_ml/core.py
+++ b/ibis_ml/core.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 import ibis
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
+from ibis.common.deferred import Deferred
 from ibis.common.dispatch import lazy_singledispatch
 
 if TYPE_CHECKING:
@@ -363,7 +364,7 @@ class Step:
 
         Notes
         -----
-        Copied from [1]_.
+        Derived from [1]_.
 
         References
         ----------
@@ -372,7 +373,12 @@ class Step:
         out = {}
         for key in self._get_param_names():
             value = getattr(self, key)
-            if deep and hasattr(value, "get_params") and not isinstance(value, type):
+            if (
+                deep
+                and hasattr(value, "get_params")
+                # `hasattr()` always returns `True` for deferred objects
+                and not isinstance(value, (type, Deferred))
+            ):
                 deep_items = value.get_params().items()
                 out.update((key + "__" + k, val) for k, val in deep_items)
             out[key] = value

--- a/ibis_ml/core.py
+++ b/ibis_ml/core.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 import ibis
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
-from ibis.common.deferred import Deferred
 from ibis.common.dispatch import lazy_singledispatch
 
 if TYPE_CHECKING:
@@ -354,8 +353,7 @@ class Step:
         Parameters
         ----------
         deep : bool, default=True
-            If True, will return the parameters for this estimator and
-            contained subobjects that are estimators.
+            Has no effect, because steps cannot contain nested substeps.
 
         Returns
         -------
@@ -370,19 +368,7 @@ class Step:
         ----------
         .. [1] https://github.com/scikit-learn/scikit-learn/blob/626b460/sklearn/base.py#L145-L167
         """
-        out = {}
-        for key in self._get_param_names():
-            value = getattr(self, key)
-            if (
-                deep
-                and hasattr(value, "get_params")
-                # `hasattr()` always returns `True` for deferred objects
-                and not isinstance(value, (type, Deferred))
-            ):
-                deep_items = value.get_params().items()
-                out.update((key + "__" + k, val) for k, val in deep_items)
-            out[key] = value
-        return out
+        return {key: getattr(self, key) for key in self._get_param_names()}
 
     def __repr__(self) -> str:
         return pprint.pformat(self)
@@ -526,8 +512,6 @@ class Recipe:
         transform: Literal["default", "pandas", "pyarrow", "polars", None] = None,
     ) -> Recipe:
         """Set output type returned by `transform`.
-
-        This is part of the standard Scikit-Learn API.
 
         Parameters
         ----------

--- a/ibis_ml/core.py
+++ b/ibis_ml/core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import inspect
 import os
 import pprint
 from collections import defaultdict
@@ -306,6 +307,77 @@ def _get_categorize_chunk() -> Callable[[str, list[str], Any], pd.DataFrame]:
 
 
 class Step:
+    @classmethod
+    def _get_param_names(cls) -> list[str]:
+        """Get parameter names for the estimator.
+
+        Notes
+        -----
+        Copied from [1]_.
+
+        References
+        ----------
+        .. [1] https://github.com/scikit-learn/scikit-learn/blob/ab2f539/sklearn/base.py#L148-L173
+        """
+        # fetch the constructor or the original constructor before
+        # deprecation wrapping if any
+        init = getattr(cls.__init__, "deprecated_original", cls.__init__)
+        if init is object.__init__:
+            # No explicit constructor to introspect
+            return []
+
+        # introspect the constructor arguments to find the model parameters
+        # to represent
+        init_signature = inspect.signature(init)
+        # Consider the constructor parameters excluding 'self'
+        parameters = [
+            p
+            for p in init_signature.parameters.values()
+            if p.name != "self" and p.kind != p.VAR_KEYWORD
+        ]
+        for p in parameters:
+            if p.kind == p.VAR_POSITIONAL:
+                raise RuntimeError(
+                    "scikit-learn estimators should always "
+                    "specify their parameters in the signature"
+                    " of their __init__ (no varargs)."
+                    f" {cls} with constructor {init_signature} doesn't "
+                    " follow this convention."
+                )
+        # Extract and sort argument names excluding 'self'
+        return sorted([p.name for p in parameters])
+
+    def get_params(self, deep=True) -> dict[str, Any]:
+        """Get parameters for this estimator.
+
+        Parameters
+        ----------
+        deep : bool, default=True
+            If True, will return the parameters for this estimator and
+            contained subobjects that are estimators.
+
+        Returns
+        -------
+        params : dict
+            Parameter names mapped to their values.
+
+        Notes
+        -----
+        Copied from [1]_.
+
+        References
+        ----------
+        .. [1] https://github.com/scikit-learn/scikit-learn/blob/626b460/sklearn/base.py#L145-L167
+        """
+        out = {}
+        for key in self._get_param_names():
+            value = getattr(self, key)
+            if deep and hasattr(value, "get_params") and not isinstance(value, type):
+                deep_items = value.get_params().items()
+                out.update((key + "__" + k, val) for k, val in deep_items)
+            out[key] = value
+        return out
+
     def __repr__(self) -> str:
         return pprint.pformat(self)
 

--- a/ibis_ml/steps/_common.py
+++ b/ibis_ml/steps/_common.py
@@ -135,6 +135,11 @@ class MutateAt(Step):
         self.expr = expr
         self.named_exprs = named_exprs
 
+    @classmethod
+    def _get_param_names(cls) -> list[str]:
+        """Get parameter names for the estimator."""
+        return ["expr", "inputs", "named_exprs"]
+
     def _repr(self) -> Iterable[tuple[str, Any]]:
         yield ("", self.inputs)
         if self.expr is not None:
@@ -191,11 +196,15 @@ class Mutate(Step):
         self.exprs = exprs
         self.named_exprs = named_exprs
 
+    @classmethod
+    def _get_param_names(cls) -> list[str]:
+        """Get parameter names for the estimator."""
+        return ["exprs", "named_exprs"]
+
     def _repr(self) -> Iterable[tuple[str, Any]]:
         for expr in self.exprs:
             yield "", expr
-        for name, expr in self.named_exprs.items():
-            yield name, expr
+        yield from self.named_exprs.items()
 
     def is_fitted(self):
         return True

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -34,6 +34,7 @@ def test_mutate_at_expr():
     res = step.transform_table(t)
     sol = t.mutate(x=_.x.abs(), y=_.y.abs())
     assert res.equals(sol)
+    assert list(step.get_params()) == ["expr", "inputs", "named_exprs"]
 
 
 def test_mutate_at_named_exprs():
@@ -44,6 +45,7 @@ def test_mutate_at_named_exprs():
     res = step.transform_table(t)
     sol = t.mutate(x=_.x.abs(), y=_.y.abs(), x_log=_.x.log(), y_log=_.y.log())
     assert res.equals(sol)
+    assert list(step.get_params()) == ["expr", "inputs", "named_exprs"]
 
 
 def test_mutate():
@@ -54,3 +56,4 @@ def test_mutate():
     res = step.transform_table(t)
     sol = t.mutate(_.x.abs().name("x_abs"), y_log=lambda t: t.y.log())
     assert res.equals(sol)
+    assert list(step.get_params()) == ["exprs", "named_exprs"]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -365,6 +365,13 @@ def test_errors_nicely_if_not_fitted(table, method):
         getattr(r, method)(table)
 
 
+def test_get_params():
+    rec = ml.Recipe(ml.ExpandDateTime(ml.timestamp()))
+
+    assert "expanddatetime__components" in rec.get_params(deep=True)
+    assert "expanddatetime__components" not in rec.get_params(deep=False)
+
+
 @pytest.mark.parametrize(
     ("step", "url"),
     [


### PR DESCRIPTION
## Description of changes

For example, from the example notebook:

```python
import ibis_ml as ml

flights_rec = ml.Recipe(
    ml.ExpandDate("date", components=["dow", "month"]),
    ml.Drop("date"),
    ml.TargetEncode(ml.nominal()),
    ml.DropZeroVariance(ml.everything()),
    ml.MutateAt("dep_time", ibis._.hour() * 60 + ibis._.minute()),
    ml.MutateAt(ml.timestamp(), ibis._.epoch_seconds()),
    # By default, PyTorch requires that the type of `X` is `np.float32`.
    # https://discuss.pytorch.org/t/mat1-and-mat2-must-have-the-same-dtype-but-got-double-and-float/197555/2
    ml.Cast(ml.numeric(), "float32"),
)
flights_rec.get_params()
```

will yield:

```python
{'steps': (ExpandDate(cols(('date',)), components=['dow', 'month']),
  Drop(cols(('date',))),
  TargetEncode(nominal(), smooth=0.0),
  DropZeroVariance(everything(), tolerance=0.0001),
  MutateAt(cols(('dep_time',)), ((_.hour() * 60) + _.minute())),
  MutateAt(timestamp(), _.epoch_seconds()),
  Cast(numeric(), 'float32')),
 'expanddate': ExpandDate(cols(('date',)), components=['dow', 'month']),
 'drop': Drop(cols(('date',))),
 'targetencode': TargetEncode(nominal(), smooth=0.0),
 'dropzerovariance': DropZeroVariance(everything(), tolerance=0.0001),
 'mutateat-1': MutateAt(cols(('dep_time',)), ((_.hour() * 60) + _.minute())),
 'mutateat-2': MutateAt(timestamp(), _.epoch_seconds()),
 'cast': Cast(numeric(), 'float32'),
 'expanddate__components': ['dow', 'month'],
 'expanddate__inputs': cols(('date',)),
 'drop__inputs': cols(('date',)),
 'targetencode__inputs': nominal(),
 'targetencode__smooth': 0.0,
 'dropzerovariance__inputs': everything(),
 'dropzerovariance__tolerance': 0.0001,
 'mutateat-1__expr': ((_.hour() * 60) + _.minute()),
 'mutateat-1__inputs': cols(('dep_time',)),
 'mutateat-1__named_exprs': {},
 'mutateat-2__expr': _.epoch_seconds(),
 'mutateat-2__inputs': timestamp(),
 'mutateat-2__named_exprs': {},
 'cast__dtype': Float32(nullable=True),
 'cast__inputs': numeric()}
```

Further down `pipe.get_params()` would also work:

```python
{'memory': None,
 'steps': [('flights_rec',
   Recipe(ExpandDate(cols(('date',)), components=['dow', 'month']),
          Drop(cols(('date',))),
          TargetEncode(nominal(), smooth=0.0),
          DropZeroVariance(everything(), tolerance=0.0001),
          MutateAt(cols(('dep_time',)), ((_.hour() * 60) + _.minute())),
          MutateAt(timestamp(), _.epoch_seconds()),
          Cast(numeric(), 'float32'))),
  ('mod',
   <class 'skorch.classifier.NeuralNetClassifier'>[uninitialized](
     module=<class '__main__.MyModule'>,
   ))],
 'verbose': False,
 'flights_rec': Recipe(ExpandDate(cols(('date',)), components=['dow', 'month']),
        Drop(cols(('date',))),
        TargetEncode(nominal(), smooth=0.0),
        DropZeroVariance(everything(), tolerance=0.0001),
        MutateAt(cols(('dep_time',)), ((_.hour() * 60) + _.minute())),
        MutateAt(timestamp(), _.epoch_seconds()),
        Cast(numeric(), 'float32')),
 'mod': <class 'skorch.classifier.NeuralNetClassifier'>[uninitialized](
   module=<class '__main__.MyModule'>,
 ),
 'flights_rec__steps': (ExpandDate(cols(('date',)), components=['dow', 'month']),
  Drop(cols(('date',))),
  TargetEncode(nominal(), smooth=0.0),
  DropZeroVariance(everything(), tolerance=0.0001),
  MutateAt(cols(('dep_time',)), ((_.hour() * 60) + _.minute())),
  MutateAt(timestamp(), _.epoch_seconds()),
  Cast(numeric(), 'float32')),
 'flights_rec__expanddate': ExpandDate(cols(('date',)), components=['dow', 'month']),
 'flights_rec__drop': Drop(cols(('date',))),
 'flights_rec__targetencode': TargetEncode(nominal(), smooth=0.0),
 'flights_rec__dropzerovariance': DropZeroVariance(everything(), tolerance=0.0001),
 'flights_rec__mutateat-1': MutateAt(cols(('dep_time',)), ((_.hour() * 60) + _.minute())),
 'flights_rec__mutateat-2': MutateAt(timestamp(), _.epoch_seconds()),
 'flights_rec__cast': Cast(numeric(), 'float32'),
 'flights_rec__expanddate__components': ['dow', 'month'],
 'flights_rec__expanddate__inputs': cols(('date',)),
 'flights_rec__drop__inputs': cols(('date',)),
 'flights_rec__targetencode__inputs': nominal(),
 'flights_rec__targetencode__smooth': 0.0,
 'flights_rec__dropzerovariance__inputs': everything(),
 'flights_rec__dropzerovariance__tolerance': 0.0001,
 'flights_rec__mutateat-1__expr': ((_.hour() * 60) + _.minute()),
 'flights_rec__mutateat-1__inputs': cols(('dep_time',)),
 'flights_rec__mutateat-1__named_exprs': {},
 'flights_rec__mutateat-2__expr': _.epoch_seconds(),
 'flights_rec__mutateat-2__inputs': timestamp(),
 'flights_rec__mutateat-2__named_exprs': {},
 'flights_rec__cast__dtype': Float32(nullable=True),
 'flights_rec__cast__inputs': numeric(),
 'mod__module': __main__.MyModule,
 'mod__criterion': torch.nn.modules.loss.NLLLoss,
 'mod__optimizer': torch.optim.sgd.SGD,
 'mod__lr': 0.1,
 'mod__max_epochs': 10,
 'mod__batch_size': 128,
 'mod__iterator_train': torch.utils.data.dataloader.DataLoader,
 'mod__iterator_valid': torch.utils.data.dataloader.DataLoader,
 'mod__dataset': skorch.dataset.Dataset,
 'mod__train_split': <skorch.dataset.ValidSplit object at 0x31cbccad0>,
 'mod__callbacks': None,
 'mod__predict_nonlinearity': 'auto',
 'mod__warm_start': False,
 'mod__verbose': 1,
 'mod__device': 'cpu',
 'mod__compile': False,
 'mod__use_caching': 'auto',
 'mod___params_to_validate': {'iterator_train__shuffle'},
 'mod__iterator_train__shuffle': True,
 'mod__classes': None,
 'mod__callbacks__epoch_timer': <skorch.callbacks.logging.EpochTimer at 0x15fc20690>,
 'mod__callbacks__train_loss': <skorch.callbacks.scoring.PassthroughScoring at 0x31c67ce50>,
 'mod__callbacks__train_loss__name': 'train_loss',
 'mod__callbacks__train_loss__lower_is_better': True,
 'mod__callbacks__train_loss__on_train': True,
 'mod__callbacks__valid_loss': <skorch.callbacks.scoring.PassthroughScoring at 0x31c7c47d0>,
 'mod__callbacks__valid_loss__name': 'valid_loss',
 'mod__callbacks__valid_loss__lower_is_better': True,
 'mod__callbacks__valid_loss__on_train': False,
 'mod__callbacks__valid_acc': <skorch.callbacks.scoring.EpochScoring at 0x1499f68d0>,
 'mod__callbacks__valid_acc__scoring': 'accuracy',
 'mod__callbacks__valid_acc__lower_is_better': False,
 'mod__callbacks__valid_acc__on_train': False,
 'mod__callbacks__valid_acc__name': 'valid_acc',
 'mod__callbacks__valid_acc__target_extractor': <function skorch.utils.to_numpy(X)>,
 'mod__callbacks__valid_acc__use_caching': True,
 'mod__callbacks__print_log': <skorch.callbacks.logging.PrintLog at 0x31cbbfc50>,
 'mod__callbacks__print_log__keys_ignored': None,
 'mod__callbacks__print_log__sink': <function print(*args, sep=' ', end='\n', file=None, flush=False)>,
 'mod__callbacks__print_log__tablefmt': 'simple',
 'mod__callbacks__print_log__floatfmt': '.4f',
 'mod__callbacks__print_log__stralign': 'right'}
```

## Issues closed

Partially addresses #135 

Will probably leave it open until address `set_params()`, too