### PR TITLE
feat(core): implement a more robust `set_params()`

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -34,7 +34,7 @@ def test_mutate_at_expr():
     res = step.transform_table(t)
     sol = t.mutate(x=_.x.abs(), y=_.y.abs())
     assert res.equals(sol)
-    assert list(step.get_params()) == ["expr", "inputs", "named_exprs"]
+    assert list(step._get_params()) == ["expr", "inputs", "named_exprs"]  # noqa: SLF001
 
 
 def test_mutate_at_named_exprs():
@@ -45,7 +45,7 @@ def test_mutate_at_named_exprs():
     res = step.transform_table(t)
     sol = t.mutate(x=_.x.abs(), y=_.y.abs(), x_log=_.x.log(), y_log=_.y.log())
     assert res.equals(sol)
-    assert list(step.get_params()) == ["expr", "inputs", "named_exprs"]
+    assert list(step._get_params()) == ["expr", "inputs", "named_exprs"]  # noqa: SLF001
 
 
 def test_mutate():
@@ -56,4 +56,4 @@ def test_mutate():
     res = step.transform_table(t)
     sol = t.mutate(_.x.abs().name("x_abs"), y_log=lambda t: t.y.log())
     assert res.equals(sol)
-    assert list(step.get_params()) == ["exprs", "named_exprs"]
+    assert list(step._get_params()) == ["exprs", "named_exprs"]  # noqa: SLF001

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -380,13 +380,13 @@ def test_set_params():
     # Nonexistent parameter in step
     with pytest.raises(
         ValueError,
-        match="Invalid parameter 'nonexistent_param' for estimator ExpandTimestamp",
+        match="Invalid parameter 'nonexistent_param' for step ExpandTimestamp",
     ):
         rec.set_params(expandtimestamp__nonexistent_param=True)
 
     # Nonexistent parameter of pipeline
     with pytest.raises(
-        ValueError, match="Invalid parameter 'expanddatetime' for estimator Recipe"
+        ValueError, match="Invalid parameter 'expanddatetime' for recipe Recipe"
     ):
         rec.set_params(expanddatetime__nonexistent_param=True)
 
@@ -395,7 +395,7 @@ def test_set_params_passes_all_parameters():
     # Make sure all parameters are passed together to set_params
     # of nested estimator.
     rec = ml.Recipe(ml.ExpandTimestamp(ml.timestamp()))
-    with patch.object(ml.ExpandTimestamp, "set_params") as mock_set_params:
+    with patch.object(ml.ExpandTimestamp, "_set_params") as mock_set_params:
         rec.set_params(
             expandtimestamp__inputs=["x", "y"],
             expandtimestamp__components=["day", "year", "hour"],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -209,7 +209,8 @@ def test_can_use_in_sklearn_pipeline():
 
     # get/set params works
     params = p.get_params()
-    p.set_params(**params)
+    p.set_params(**params | {"recipe__scalestandard__inputs": ml.numeric()})
+    assert p["recipe"].steps[1].inputs == ml.numeric()
 
     # fit and predict work
     p.fit(X, y)


### PR DESCRIPTION
Related to #135 and #136 

Before this PR, it wasn't possible to call `set_params()` on `Step` objects, and `Recipe.set_params()` only trivially set the `steps` param. With this PR, you can actually set the parameters listed by `Recipe.get_params()` (and `Step.get_params()`), which is more robust and akin to scikit-learn.