### PR TITLE
chore: add polars to the dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ doc = [
   "torch",
   "xgboost",
 ]
-dev = ["ibis-framework[duckdb,examples]", "pytest", "pytest-cov", "scikit-learn", "skorch", "torch", "xgboost"]
+dev = ["ibis-framework[duckdb,examples]", "pytest", "pytest-cov", "polars", "scikit-learn", "skorch", "torch", "xgboost"]
 
 [project.urls]
 Home = "https://ibis-project.github.io/ibis-ml/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ doc = [
   "torch",
   "xgboost",
 ]
-dev = ["ibis-framework[duckdb,examples]", "pytest", "pytest-cov", "polars", "scikit-learn", "skorch", "torch", "xgboost"]
+dev = ["ibis-framework[duckdb,examples]", "polars", "pytest", "pytest-cov", "scikit-learn", "skorch", "torch", "xgboost"]
 
 [project.urls]
 Home = "https://ibis-project.github.io/ibis-ml/"


### PR DESCRIPTION
The polars integration wasn't being tested since it wasn't installed on CI.