### PR TITLE
fix: handle span NoneType exception in skorch patching

### DIFF
--- a/ibis_ml/__init__.py
+++ b/ibis_ml/__init__.py
@@ -40,7 +40,9 @@ pprint.PrettyPrinter._safe_repr = _safe_repr  # noqa: SLF001
 def _auto_patch_skorch() -> None:
     try:
         import skorch.net
-    except ImportError:
+    except (ImportError, AttributeError):
+        # ImportError: skorch not installed
+        # AttributeError: Python 3.13 docstring parsing issue in skorch
         return
 
     import ibis.expr.types as ir


### PR DESCRIPTION
This was giving issues when trying to import ibis_ml.

With Python 3.13 there was a change with the doctoring handling causing something upstream to break. This was resolved in https://github.com/skorch-dev/skorch/pull/1082 but there has not been a new release.